### PR TITLE
Journal order done by latest date campaign top

### DIFF
--- a/scripts/EncounterJournal.ts
+++ b/scripts/EncounterJournal.ts
@@ -116,6 +116,37 @@ class EncounterJournal {
         content: data,
       },
     });
+
+    this.SortJournalData();
+  }
+
+  private static async SortJournalData() {
+    const journalEntry = game.journal?.find(
+      (e) => e.name === "Encounter Statistics"
+    );
+
+    let sortValue = 2000;
+
+    const sortedJournalsByName = new Map(
+      [...journalEntry.pages.entries()].sort((a, b) =>
+        a.name > b.name ? 1 : -1
+      )
+    );
+
+    sortedJournalsByName.forEach((journalEntryPage) => {
+      if (
+        journalEntryPage.getFlag("encounter-stats", "campaignstats") === "view"
+      ) {
+        journalEntryPage.update({
+          sort: 1000,
+        });
+      } else {
+        journalEntryPage.update({
+          sort: sortValue,
+        });
+        sortValue = sortValue + 1000;
+      }
+    });
   }
 
   // Temporary for migration from Journal

--- a/scripts/panels/CampaignStatsPanel.ts
+++ b/scripts/panels/CampaignStatsPanel.ts
@@ -1,3 +1,4 @@
+import CampaignStat from "../CampaignStat";
 import Gamemaster from "../Helpers/Gamemaster";
 import Trans from "../Helpers/Trans";
 import { MODULE_NAME } from "../Settings";
@@ -51,7 +52,7 @@ export class CampaignStatsPanel extends FormApplication {
     if (typeof json === "string") {
       json = JSON.parse(json);
     }
-    Gamemaster.SetStats(json);
+    CampaignStat.Save(json);
   }
 
   async importFromJSONDialog() {


### PR DESCRIPTION
# Description

Sorts Journals by latest date instead of latest being at the end of the list.

Also ensures Campaign Data remains at the top.

Fixes #247