### PR TITLE
Fix for monks-enhanced-journal errors

### DIFF
--- a/scripts/EncounterJournal.ts
+++ b/scripts/EncounterJournal.ts
@@ -111,11 +111,20 @@ class EncounterJournal {
       return;
     }
 
-    await journalEntryPage?.update({
-      text: {
-        content: data,
-      },
-    });
+    await game.journal?.getName(this.JOURNAL_TITLE).updateEmbeddedDocuments(
+      "JournalEntryPage",
+      [
+        {
+          _id: journalEntryPage._id,
+          flags: {},
+          type: "text",
+          text: {
+            content: data,
+          },
+        },
+      ],
+      { diff: false, render: false }
+    );
 
     this.SortJournalData();
   }


### PR DESCRIPTION
# Description

When a flag is not set on a JournalEntryPage content update, errors are recorded in the console.

