### PR TITLE
Add UI confirmation messages to import and delete stats

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -77,5 +77,7 @@
     "EncounterStats.Settings.Configure": "Configure",
     "EncounterStats.Settings.Import": "Import",
     "EncounterStats.Settings.FileUploadError": "You did not upload a data file!",
-    "EncounterStats.Settings.Cancel": "Cancel"
+    "EncounterStats.Settings.Cancel": "Cancel",
+    "EncounterStats.Settings.CampaignStatsDeleted": "Successfully deleted campaign stats.",
+    "EncounterStats.Settings.CampaignStatsImported": "Successfully imported campaign stats."
 }

--- a/scripts/Helpers/Gamemaster.test.ts
+++ b/scripts/Helpers/Gamemaster.test.ts
@@ -1,11 +1,15 @@
+import CampaignStat from "../CampaignStat";
 import Gamemaster from "./Gamemaster";
 
 const mockSetFlag = jest.fn();
 const mockGetFlag = jest.fn();
+const mockCampaignStatSave = jest.fn();
+CampaignStat.Save = mockCampaignStatSave;
 
 beforeEach(() => {
   mockSetFlag.mockClear();
   mockGetFlag.mockClear();
+  mockCampaignStatSave.mockClear();
 });
 
 describe("Gamemaster", () => {
@@ -152,6 +156,7 @@ describe("Gamemaster", () => {
       });
       test("it deletes and resets the data", async () => {
         Gamemaster.DeleteStats();
+        expect(mockCampaignStatSave).toBeCalledWith(Gamemaster.DEFAULT_DATA);
         expect(mockSetFlag).toBeCalledWith("encounter-stats", "campaign-stats", Gamemaster.DEFAULT_DATA);
       });
     });

--- a/scripts/Helpers/Gamemaster.ts
+++ b/scripts/Helpers/Gamemaster.ts
@@ -1,3 +1,5 @@
+import CampaignStat from "../CampaignStat";
+
 class Gamemaster {
   static readonly FLAG_SCOPE = "encounter-stats";
   static readonly FLAG_NAME = "campaign-stats";
@@ -34,6 +36,7 @@ class Gamemaster {
       this.FLAG_NAME,
       Gamemaster.DEFAULT_DATA
     );
+    CampaignStat.Save(Gamemaster.DEFAULT_DATA);
   }
 }
 

--- a/scripts/panels/CampaignStatsPanel.ts
+++ b/scripts/panels/CampaignStatsPanel.ts
@@ -32,6 +32,9 @@ export class CampaignStatsPanel extends FormApplication {
 
   deleteStatistics() {
     Gamemaster.DeleteStats();
+    return ui.notifications?.info(
+      Trans.Get("Settings.CampaignStatsDeleted")
+    );
   }
 
   // @ts-expect-error TS(2416): Property '_updateObject' in type 'ChatSettingsPane... Remove this comment to see the full error message
@@ -53,6 +56,9 @@ export class CampaignStatsPanel extends FormApplication {
       json = JSON.parse(json);
     }
     CampaignStat.Save(json);
+    return ui.notifications?.info(
+      Trans.Get("Settings.CampaignStatsImported")
+    );
   }
 
   async importFromJSONDialog() {


### PR DESCRIPTION
# Description

- Add UI confirmation messages to import and delete stats
- Update campaign stat journal after delete data


Fixes #307 
