### PR TITLE
#minor Fix for multiple/old combats.

### DIFF
--- a/scripts/CombatFlag.test.ts
+++ b/scripts/CombatFlag.test.ts
@@ -14,20 +14,18 @@ beforeEach(() => {
 const multiCombat = [combatOne, combatTwo];
 
 describe("CombatFlag", () => {
-  describe("IsSet", () => {
+  describe("IsCurrentSceneCombatSet", () => {
     describe("given a flag is set on the active combat", () => {
       beforeEach(() => {
         (global as any).game = {
-          combats: [
-            {
-              active: true,
-              getFlag: jest.fn().mockReturnValue({}),
-            },
-          ],
+          combat: {
+            active: true,
+            getFlag: jest.fn().mockReturnValue({}),
+          },
         };
       });
       test("it returns true", async () => {
-        const result = await CombatFlag.IsSet(STORAGE_NAME);
+        const result = await CombatFlag.IsCurrentSceneCombatSet(STORAGE_NAME);
         expect(result).toBeTruthy();
       });
     });
@@ -35,16 +33,14 @@ describe("CombatFlag", () => {
     describe("given no flag is set on the active combat", () => {
       beforeEach(() => {
         (global as any).game = {
-          combats: [
-            {
-              active: true,
-              getFlag: jest.fn().mockReturnValue(undefined),
-            },
-          ],
+          combat: {
+            active: true,
+            getFlag: jest.fn().mockReturnValue(undefined),
+          },
         };
       });
       test("it returns false", async () => {
-        const result = await CombatFlag.IsSet(STORAGE_NAME);
+        const result = await CombatFlag.IsCurrentSceneCombatSet(STORAGE_NAME);
         expect(result).toBeFalsy();
       });
     });
@@ -52,11 +48,11 @@ describe("CombatFlag", () => {
     describe("given there is no active combat", () => {
       beforeEach(() => {
         (global as any).game = {
-          combats: [],
+          combat: undefined,
         };
       });
       test("it returns false", async () => {
-        const result = await CombatFlag.IsSet(STORAGE_NAME);
+        const result = await CombatFlag.IsCurrentSceneCombatSet(STORAGE_NAME);
         expect(result).toBeFalsy();
       });
     });
@@ -64,16 +60,14 @@ describe("CombatFlag", () => {
     describe("given there is no active combat but combat is set", () => {
       beforeEach(() => {
         (global as any).game = {
-          combats: [
-            {
-              active: false,
-              getFlag: jest.fn().mockReturnValue({}),
-            },
-          ],
+          combat: {
+            active: false,
+            getFlag: jest.fn().mockReturnValue({}),
+          },
         };
       });
       test("it returns false", async () => {
-        const result = await CombatFlag.IsSet(STORAGE_NAME);
+        const result = await CombatFlag.IsCurrentSceneCombatSet(STORAGE_NAME);
         expect(result).toBeFalsy();
       });
     });
@@ -115,12 +109,10 @@ describe("CombatFlag", () => {
     describe("given there is no valid active combat", () => {
       beforeEach(() => {
         (global as any).game = {
-          combats: [
-            {
-              active: false,
-              getFlag: jest.fn().mockReturnValue({}),
-            },
-          ],
+          combat: {
+            active: false,
+            getFlag: jest.fn().mockReturnValue({}),
+          },
         };
       });
       test("it returns undefined", async () => {
@@ -133,6 +125,10 @@ describe("CombatFlag", () => {
       describe("given no actor id is passed", () => {
         beforeEach(() => {
           (global as any).game = {
+            combat: {
+              active: true,
+              getFlag: jest.fn().mockReturnValue(combatOne),
+            },
             combats: [
               {
                 active: true,
@@ -156,6 +152,10 @@ describe("CombatFlag", () => {
         describe("and the actor is in the active combat", () => {
           beforeEach(() => {
             (global as any).game = {
+              combat: {
+                active: true,
+                getFlag: jest.fn().mockReturnValue(combatOne),
+              },
               combats: [
                 {
                   active: true,
@@ -181,6 +181,10 @@ describe("CombatFlag", () => {
         describe("and the actor is not in the active combat", () => {
           beforeEach(() => {
             (global as any).game = {
+              combat: {
+                active: true,
+                getFlag: jest.fn().mockReturnValue(combatOne),
+              },
               combats: [
                 {
                   active: true,
@@ -206,6 +210,10 @@ describe("CombatFlag", () => {
         describe("and the actor is not in any combat", () => {
           beforeEach(() => {
             (global as any).game = {
+              combat: {
+                active: true,
+                getFlag: jest.fn().mockReturnValue(combatOne),
+              },
               combats: [
                 {
                   active: true,

--- a/scripts/CombatFlag.ts
+++ b/scripts/CombatFlag.ts
@@ -1,21 +1,17 @@
 export default class CombatFlag {
-  static async IsSet(item: string): boolean {
-    const combat = await game.combats.find((f) => f.active);
+  static async IsCurrentSceneCombatSet(item: string): boolean {
+    if (!game.combat?.active) return false;
 
-    if (!combat) return false;
-
-    return combat.getFlag("encounter-stats", item) !== undefined;
+    return game.combat?.getFlag("encounter-stats", item) !== undefined;
   }
 
   static async Get(
     item: string,
     actorId?: string
   ): Promise<Encounter | undefined> {
-    if (!(await CombatFlag.IsSet(item))) return;
+    if (!(await CombatFlag.IsCurrentSceneCombatSet(item))) return;
 
-    let flagValue = await game.combats
-      .find((f) => f.active)
-      .getFlag("encounter-stats", item);
+    let flagValue = game.combat?.getFlag("encounter-stats", item);
 
     // if actorId is passed
     if (actorId) {

--- a/scripts/StatManager.test.ts
+++ b/scripts/StatManager.test.ts
@@ -4,10 +4,10 @@ import Logger from "./Helpers/Logger";
 import EncounterJournal from "./EncounterJournal";
 import EncounterRenderer from "./EncounterRenderer";
 
-const mockCombatFlagIsSet = jest.fn();
+const mockCombatFlagIsCurrentSceneCombatSet = jest.fn();
 const mockCombatFlagGet = jest.fn();
 const mockCombatFlagSave = jest.fn();
-CombatFlag.IsSet = mockCombatFlagIsSet;
+CombatFlag.IsCurrentSceneCombatSet = mockCombatFlagIsCurrentSceneCombatSet;
 CombatFlag.Get = mockCombatFlagGet;
 CombatFlag.Save = mockCombatFlagSave;
 
@@ -18,7 +18,7 @@ const mockLoggerError = jest.fn();
 Logger.error = mockLoggerError;
 
 beforeEach(() => {
-  mockCombatFlagIsSet.mockClear();
+  mockCombatFlagIsCurrentSceneCombatSet.mockClear();
   mockCombatFlagGet.mockClear();
   mockCombatFlagSave.mockClear();
   mockEncounterJournalUpdateJournalData.mockClear();
@@ -39,9 +39,9 @@ describe("StatManager", () => {
           active: false,
         },
       };
-      mockCombatFlagIsSet.mockReturnValueOnce(true);
+      mockCombatFlagIsCurrentSceneCombatSet.mockReturnValueOnce(false);
       const isInCombat = await StatManager.IsInCombat();
-      expect(mockCombatFlagIsSet).toBeCalledWith("encounter-stats-data");
+      expect(mockCombatFlagIsCurrentSceneCombatSet).toBeCalledWith("encounter-stats-data");
       expect(isInCombat).toBeFalsy();
     });
 
@@ -51,9 +51,9 @@ describe("StatManager", () => {
           active: false,
         },
       };
-      mockCombatFlagIsSet.mockReturnValueOnce(false);
+      mockCombatFlagIsCurrentSceneCombatSet.mockReturnValueOnce(false);
       const isInCombat = await StatManager.IsInCombat();
-      expect(mockCombatFlagIsSet).toBeCalledWith("encounter-stats-data");
+      expect(mockCombatFlagIsCurrentSceneCombatSet).toBeCalledWith("encounter-stats-data");
       expect(isInCombat).toBeFalsy();
     });
 
@@ -63,9 +63,9 @@ describe("StatManager", () => {
           active: true,
         },
       };
-      mockCombatFlagIsSet.mockReturnValueOnce(true);
+      mockCombatFlagIsCurrentSceneCombatSet.mockReturnValueOnce(true);
       const isInCombat = await StatManager.IsInCombat();
-      expect(mockCombatFlagIsSet).toBeCalledWith("encounter-stats-data");
+      expect(mockCombatFlagIsCurrentSceneCombatSet).toBeCalledWith("encounter-stats-data");
       expect(isInCombat).toBeTruthy();
     });
   });

--- a/scripts/StatManager.ts
+++ b/scripts/StatManager.ts
@@ -6,10 +6,8 @@ import EncounterRenderer from "./EncounterRenderer";
 
 class StatManager {
   static async IsInCombat() {
-    const isFlagSet = await CombatFlag.IsSet(STORAGE_NAME);
-    if (!game.combat?.active && isFlagSet) {
-      return false;
-    }
+    const isFlagSet = await CombatFlag.IsCurrentSceneCombatSet(STORAGE_NAME);
+
     return isFlagSet;
   }
 


### PR DESCRIPTION
# Description

Now uses currently active scene as the basis to setup and track encounters.

Still looks across combats if combatant does not exist in current scene.

Fixes #306
Fixes #311