### PR TITLE
Update module.json for v10 #patch

### DIFF
--- a/module.json
+++ b/module.json
@@ -37,7 +37,7 @@
 			"label": "Encounter Statistics Example Macros",
 			"path": "packs/encounter-statistics.db",
 			"module": "encounter-statistics",
-			"entity": "Macro"
+			"type": "Macro"
 		}
 	],
 	"conflicts": [],


### PR DESCRIPTION
# Description

This change to module.json changes the entity label in the packs array to type, to comply with the current API in v10, as entity has be deprecated, and throws a compatibility warning in foundry.

Fixes #337 

## Bump type

Ensure the bump type is set in the PR title

- `#patch` (default)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)