### PR TITLE
#minor Fix for non midi criticals are tracked in combat

### DIFF
--- a/scripts/stats/DND5eStat.test.ts
+++ b/scripts/stats/DND5eStat.test.ts
@@ -51,6 +51,7 @@ const encounterDefaultWorkflowDamage: EncounterWorkflow = {
   },
   damageTotal: 41,
   damageMultipleEnemiesTotal: 41,
+  isCritical: false,
   type: CombatDetailType.Damage,
 };
 
@@ -136,7 +137,6 @@ describe("DND5eStat", () => {
         },
         round: 1,
         attackTotal: 19,
-        isCritical: false,
         isFumble: false,
         advantage: true,
         disadvantage: false,

--- a/scripts/stats/DND5eStat.ts
+++ b/scripts/stats/DND5eStat.ts
@@ -27,9 +27,9 @@ export default class DND5eStat extends Stat {
         newCombatantEvent.damageTotal = workflow.damageTotal;
         newCombatantEvent.damageMultipleEnemiesTotal =
           workflow.damageMultipleEnemiesTotal;
+        newCombatantEvent.isCritical = workflow.isCritical;
       } else if (workflow.type === CombatDetailType.Attack) {
         newCombatantEvent.attackTotal = workflow.attackTotal;
-        newCombatantEvent.isCritical = workflow.isCritical;
         newCombatantEvent.isFumble = workflow.isFumble;
         newCombatantEvent.advantage = workflow.advantage;
         newCombatantEvent.disadvantage = workflow.disadvantage;


### PR DESCRIPTION
# Description

This allows for weapons with custom critical thresholds

Fixes #282