### PR TITLE
Ready Set Roll for D&D5e integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,16 @@ assignees: johnnolan
 A clear and concise description of what the bug is.
 
 **What version of FoundryVTT are you using?**
-Version 0.8.7? 0.7.9?
+Foundry Version: 
+
+**What version of dnd5e are you using?**
+DND5e Version: 
+
+**What roll module are you using?**
+
+- [ ] None
+- [ ] Midi-QOL
+- [ ] Ready Set Roll for DND5e
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -20,8 +29,8 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Screenshot any console errors**
+A screenshot of any console errors if there are any
 
 **Screenshots**
 Please add a screenshot of your chat log and the report with the problem. This helps us identify your setup correctly 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ Capture your Players attacks, damage, healing, dice rolls, custom events and mor
 
 ## Supported Modules
 
+Key points when using in conjunction with this module
+
 - MIDI-QOL
     - You must use targeting in order for this module to record your stats correctly
 - Ready Set Roll for D&D5e
     - Does not track targeted enemies so saves and damage across multiple targets is not currently supported
+    - Attack rolls do not count towards dice sprees
 
 ## Current features are
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,17 @@ Capture your Players attacks, damage, healing, dice rolls, custom events and mor
 ## Supported Systems
 
 * `dnd5e`
-* `pf2e` (**ALPHA** - please do not submit bug tickets yet, once in BETA I would love your feedback! See the issues on github tagged [PF2e](https://github.com/johnnolan/encounter-stats/labels/pf2e) for upcoming work)
+* `pf2e` (**ALPHA** - See the issues on github tagged [PF2e](https://github.com/johnnolan/encounter-stats/labels/pf2e) for upcoming work)
 
-**NOTE FOR MIDI-QOL USERS: You must use targeting in order for this module to record your stats correctly**
+## Supported Modules
+
+- MIDI-QOL
+    - You must use targeting in order for this module to record your stats correctly
+- Ready Set Roll for D&D5e
+    - Does not track targeted enemies so saves and damage across multiple targets is not currently supported
 
 ## Current features are
 
-* Works with standard roles and `midi-qol`
 * [Track your own custom campaign events via Macros](#track-your-own-custom-campaign-events)
 * Enemies must be targetted in order for kills to be registered
     * Multiple targets will show roll damage and roll damage x targets
@@ -103,10 +107,6 @@ Hooks.callAll(`encounter-stats.customEvent`, {
 In the campaign report, the results look like so
 
 [![Example Custom Campaign Report](https://raw.githubusercontent.com/johnnolan/encounter-stats/main/images/custom-events.jpg)](https://raw.githubusercontent.com/johnnolan/encounter-stats/main/images/custom-events.jpg)
-
-## Dependencies
-
-* `dnd5e` game system
 
 ## Contributing
 

--- a/scripts/Handlers.ts
+++ b/scripts/Handlers.ts
@@ -8,6 +8,7 @@ import { ChatType, RoleType } from "./enums";
 import Logger from "./Helpers/Logger";
 import { EncounterWorkflow } from "EncounterWorkflow";
 import PF2eStat from "./stats/PF2eStat";
+import ReadySetRollStat from "./stats/ReadySetRollStat";
 
 export function OnCustomEvent(customEvent: HookCustomEvent): void {
   CampaignStat.AddCustomEvent(customEvent);
@@ -144,6 +145,8 @@ export async function OnEncounterWorkflowComplete(
     stat = new PF2eStat();
   } else if (chatType === ChatType.MidiQol) {
     stat = new MidiQolStat();
+  } else if (chatType === ChatType.RSR) {
+    stat = new ReadySetRollStat();
   } else {
     return;
   }

--- a/scripts/SetupHooksDND5e.ts
+++ b/scripts/SetupHooksDND5e.ts
@@ -286,11 +286,6 @@ export default class SetupHooksDND5e {
           case "rsr5e.rollProcessed":
             OnEncounterWorkflowComplete(payload.data.workflow, ChatType.RSR);
             OnTrackDice(payload.data.rollCheck);
-            OnTrackRollStreak(
-              payload.data.workflow.diceTotal,
-              payload.data.rollCheck.name,
-              payload.data.workflow.actor.id
-            );
             break;
           case "midi-qol.RollComplete":
             OnEncounterWorkflowComplete(

--- a/scripts/SetupHooksDND5e.ts
+++ b/scripts/SetupHooksDND5e.ts
@@ -16,7 +16,6 @@ import MidiQol from "./parsers/MidiQol";
 import { CombatDetailType, ChatType } from "./enums";
 import Stat from "./stats/Stat";
 import ReadySetRoll from "./parsers/ReadySetRoll";
-import ReadySetRollStat from "./stats/ReadySetRollStat";
 
 export default class SetupHooksDND5e {
   static SOCKET_NAME = "module.encounter-stats";
@@ -82,19 +81,19 @@ export default class SetupHooksDND5e {
         window.Hooks.on(
           "rsr5e.rollProcessed",
           async function (workflow: ReadySetRollWorkflow) {
-            const rollData = ReadySetRoll.ParseRollData(workflow);
+            //const rollData = ReadySetRoll.ParseRollData(workflow);
             const rollCheck = ReadySetRoll.RollCheck(workflow);
             const readySetRollWorkflow = ReadySetRoll.ParseWorkflow(workflow);
             OnEncounterWorkflowComplete(readySetRollWorkflow, ChatType.RSR);
             OnTrackDice(rollCheck);
 
-            if (rollCheck && readySetRollWorkflow && rollData.attackData) {
+            /*if (rollCheck && readySetRollWorkflow && rollData.attackData) {
               OnTrackRollStreak(
                 readySetRollWorkflow.diceTotal,
                 rollCheck.name,
                 readySetRollWorkflow.actor.id
               );
-            }
+            }*/
           }
         );
       }
@@ -365,7 +364,7 @@ export default class SetupHooksDND5e {
       ) {
         OnTrackKill(actor.name, game.combat.current.tokenId);
       }
-      if (
+      /*if (
         actor.name &&
         game.modules.get("ready-set-roll-5e")?.active &&
         !actor.hasPlayerOwner &&
@@ -378,7 +377,7 @@ export default class SetupHooksDND5e {
         // TODO: Update current combat tokens last attack with dhp
         // What about multiple? Set property to say multiple, if is false, 0 then add each after?
         //OnTrackKill(actor.name, game.combat.current.tokenId);
-      }
+      }*/
     }
     if (
       diff.system?.attributes?.hp &&

--- a/scripts/SetupHooksDND5e.ts
+++ b/scripts/SetupHooksDND5e.ts
@@ -350,11 +350,7 @@ export default class SetupHooksDND5e {
     );
   }
 
-  static async updateActorToken(
-    actor: Actor,
-    diff: unknown,
-    diffResult: unknown = undefined
-  ) {
+  static async updateActorToken(actor: Actor, diff: unknown) {
     if (StatManager.IsInCombat()) {
       if (
         actor.name &&

--- a/scripts/SetupHooksDND5e.ts
+++ b/scripts/SetupHooksDND5e.ts
@@ -81,19 +81,10 @@ export default class SetupHooksDND5e {
         window.Hooks.on(
           "rsr5e.rollProcessed",
           async function (workflow: ReadySetRollWorkflow) {
-            //const rollData = ReadySetRoll.ParseRollData(workflow);
             const rollCheck = ReadySetRoll.RollCheck(workflow);
             const readySetRollWorkflow = ReadySetRoll.ParseWorkflow(workflow);
             OnEncounterWorkflowComplete(readySetRollWorkflow, ChatType.RSR);
             OnTrackDice(rollCheck);
-
-            /*if (rollCheck && readySetRollWorkflow && rollData.attackData) {
-              OnTrackRollStreak(
-                readySetRollWorkflow.diceTotal,
-                rollCheck.name,
-                readySetRollWorkflow.actor.id
-              );
-            }*/
           }
         );
       }
@@ -360,20 +351,6 @@ export default class SetupHooksDND5e {
       ) {
         OnTrackKill(actor.name, game.combat.current.tokenId);
       }
-      /*if (
-        actor.name &&
-        game.modules.get("ready-set-roll-5e")?.active &&
-        !actor.hasPlayerOwner &&
-        diffResult &&
-        diffResult.dhp < 0 &&
-        game.combat?.current?.tokenId
-      ) {
-        const r = new ReadySetRollStat();
-        await r.UpdateDamageForLastAttack(game.combat?.current?.tokenId, diffResult.dhp);
-        // TODO: Update current combat tokens last attack with dhp
-        // What about multiple? Set property to say multiple, if is false, 0 then add each after?
-        //OnTrackKill(actor.name, game.combat.current.tokenId);
-      }*/
     }
     if (
       diff.system?.attributes?.hp &&

--- a/scripts/SetupHooksDND5e.ts
+++ b/scripts/SetupHooksDND5e.ts
@@ -81,19 +81,18 @@ export default class SetupHooksDND5e {
         window.Hooks.on(
           "rsr5e.rollProcessed",
           async function (workflow: ReadySetRollWorkflow) {
-            if (workflow.fields.length === 5) {
-              const rollCheck = ReadySetRoll.RollCheck(workflow);
-              const readySetRollWorkflow = ReadySetRoll.ParseWorkflow(workflow);
-              OnEncounterWorkflowComplete(readySetRollWorkflow, ChatType.RSR);
-              OnTrackDice(rollCheck);
+            const rollData = ReadySetRoll.ParseRollData(workflow);
+            const rollCheck = ReadySetRoll.RollCheck(workflow);
+            const readySetRollWorkflow = ReadySetRoll.ParseWorkflow(workflow);
+            OnEncounterWorkflowComplete(readySetRollWorkflow, ChatType.RSR);
+            OnTrackDice(rollCheck);
 
-              if (rollCheck && readySetRollWorkflow) {
-                OnTrackRollStreak(
-                  readySetRollWorkflow.diceTotal,
-                  rollCheck.name,
-                  readySetRollWorkflow.actor.id
-                );
-              }
+            if (rollCheck && readySetRollWorkflow && rollData.attackData) {
+              OnTrackRollStreak(
+                readySetRollWorkflow.diceTotal,
+                rollCheck.name,
+                readySetRollWorkflow.actor.id
+              );
             }
           }
         );

--- a/scripts/SetupHooksDND5e.ts
+++ b/scripts/SetupHooksDND5e.ts
@@ -15,6 +15,7 @@ import DND5e from "./parsers/DND5e";
 import MidiQol from "./parsers/MidiQol";
 import { CombatDetailType, ChatType } from "./enums";
 import Stat from "./stats/Stat";
+import ReadySetRoll from "./parsers/ReadySetRoll";
 
 export default class SetupHooksDND5e {
   static SOCKET_NAME = "module.encounter-stats";
@@ -76,6 +77,28 @@ export default class SetupHooksDND5e {
         );
       }
 
+      if (game.modules.get("ready-set-roll-5e")?.active) {
+        window.Hooks.on(
+          "rsr5e.rollProcessed",
+          async function (workflow: ReadySetRollWorkflow) {
+            if (workflow.fields.length === 5) {
+              const rollCheck = ReadySetRoll.RollCheck(workflow);
+              const readySetRollWorkflow = ReadySetRoll.ParseWorkflow(workflow);
+              OnEncounterWorkflowComplete(readySetRollWorkflow, ChatType.RSR);
+              OnTrackDice(rollCheck);
+
+              if (rollCheck && readySetRollWorkflow) {
+                OnTrackRollStreak(
+                  readySetRollWorkflow.diceTotal,
+                  rollCheck.name,
+                  readySetRollWorkflow.actor.id
+                );
+              }
+            }
+          }
+        );
+      }
+
       Hooks.on(
         "encounter-stats.customEvent",
         async function (customEvent: HookCustomEvent) {
@@ -116,8 +139,26 @@ export default class SetupHooksDND5e {
         );
       }
 
+      if (game.modules.get("ready-set-roll-5e")?.active) {
+        window.Hooks.on(
+          "rsr5e.rollProcessed",
+          async function (workflow: ReadySetRollWorkflow) {
+            game.socket?.emit(SetupHooksDND5e.SOCKET_NAME, {
+              event: "rsr5e.rollProcessed",
+              data: {
+                workflow: ReadySetRoll.ParseWorkflow(workflow),
+                rollCheck: ReadySetRoll.RollCheck(workflow),
+              },
+            });
+          }
+        );
+      }
+
       window.Hooks.on("dnd5e.useItem", async function (item: Item) {
-        if (!game.modules.get("midi-qol")?.active) {
+        if (
+          !game.modules.get("midi-qol")?.active &&
+          !game.modules.get("ready-set-roll-5e")?.active
+        ) {
           game.socket?.emit(SetupHooksDND5e.SOCKET_NAME, {
             event: "dnd5e.useItem",
             data: {
@@ -136,7 +177,10 @@ export default class SetupHooksDND5e {
       window.Hooks.on(
         "dnd5e.rollAttack",
         async function (item: Item5e, roll: Roll) {
-          if (!game.modules.get("midi-qol")?.active) {
+          if (
+            !game.modules.get("midi-qol")?.active &&
+            !game.modules.get("ready-set-roll-5e")?.active
+          ) {
             game.socket?.emit(SetupHooksDND5e.SOCKET_NAME, {
               event: "dnd5e.rollAttack",
               data: {
@@ -156,7 +200,10 @@ export default class SetupHooksDND5e {
       window.Hooks.on(
         "dnd5e.rollDamage",
         async function (item: Item5e, roll: Roll) {
-          if (!game.modules.get("midi-qol")?.active) {
+          if (
+            !game.modules.get("midi-qol")?.active &&
+            !game.modules.get("ready-set-roll-5e")?.active
+          ) {
             game.socket?.emit(SetupHooksDND5e.SOCKET_NAME, {
               event: "dnd5e.rollDamage",
               data: {
@@ -245,6 +292,15 @@ export default class SetupHooksDND5e {
         switch (payload.event) {
           case "encounter-stats.customEvent":
             OnCustomEvent(payload.data.customEvent);
+            break;
+          case "rsr5e.rollProcessed":
+            OnEncounterWorkflowComplete(payload.data.workflow, ChatType.RSR);
+            OnTrackDice(payload.data.rollCheck);
+            OnTrackRollStreak(
+              payload.data.workflow.diceTotal,
+              payload.data.rollCheck.name,
+              payload.data.workflow.actor.id
+            );
             break;
           case "midi-qol.RollComplete":
             OnEncounterWorkflowComplete(

--- a/scripts/enums.ts
+++ b/scripts/enums.ts
@@ -3,6 +3,7 @@ export enum CombatDetailType {
   Attack = "attack",
   ItemCard = "itemCard",
   MidiQol = "midiqol",
+  ReadySetRoll = "readysetroll",
   None = "none",
 }
 
@@ -41,4 +42,5 @@ export enum ChatType {
   DND5e = 1,
   MidiQol = 2,
   PF2e = 3,
+  RSR = 4,
 }

--- a/scripts/parsers/ReadySetRoll.test.ts
+++ b/scripts/parsers/ReadySetRoll.test.ts
@@ -350,7 +350,7 @@ describe("ReadySetRoll", () => {
           isFumble: false,
           disadvantage: false,
           attackTotal: 12,
-          diceTotal: 12,
+          diceTotal: undefined,
           damageTotal: 21,
           item: {
             id: "itemId",

--- a/scripts/parsers/ReadySetRoll.test.ts
+++ b/scripts/parsers/ReadySetRoll.test.ts
@@ -1,0 +1,505 @@
+import { CombatDetailType } from "../enums";
+import ReadySetRoll from "./ReadySetRoll";
+
+const readySetRollWorkflow: ReadySetRollWorkflow = {
+  "_currentId": 5,
+  "itemId": "C3c6l9SPMCqMiceV",
+  "actorId": "5H4YnyD6zf9vcJ3P",
+  "item": {
+    "id": "itemId",
+    "name": "Flame Tongue Greatsword",
+    "link": "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+    "type": "sword",
+    "img": "itemImageUrl",
+    "system": {
+      "actionType": "mwak"
+    }
+  },
+  "tokenId": null,
+  "params": {
+      "hasAdvantage": true,
+      "hasDisadvantage": false,
+      "isCrit": false,
+      "isFumble": false,
+      "isMultiRoll": false,
+      "isAltRoll": false,
+      "elvenAccuracy": false,
+      "slotLevel": 0,
+      "spellLevel": 0
+  },
+  "fields": [
+      [
+          "header",
+          {
+              "title": "Fire Bolt",
+              "slotLevel": 0
+          }
+      ],
+      [
+          "description",
+          {
+              "content": "<p>You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn't being worn or carried.</p>\n<p>This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).</p>",
+              "isFlavor": false
+          }
+      ],
+      [
+          "blank",
+          {
+              "display": true
+          }
+      ],
+      [
+          "attack",
+          {
+              "roll": {
+                  "class": "D20Roll",
+                  "options": {
+                      "flavor": "Fire Bolt - Attack Roll",
+                      "advantageMode": 0,
+                      "defaultRollMode": "publicroll",
+                      "rollMode": "publicroll",
+                      "critical": 20,
+                      "fumble": 1,
+                      "halflingLucky": false,
+                      "configured": true
+                  },
+                  "dice": [],
+                  "formula": "1d20 + 2 + 4 + 6",
+                  "terms": [
+                      {
+                          "class": "Die",
+                          "options": {
+                              "critical": 20,
+                              "fumble": 1
+                          },
+                          "evaluated": true,
+                          "number": 1,
+                          "faces": 20,
+                          "modifiers": [],
+                          "results": [
+                              {
+                                  "result": 8,
+                                  "active": true
+                              }
+                          ]
+                      },
+                      {
+                          "class": "OperatorTerm",
+                          "options": {},
+                          "evaluated": true,
+                          "operator": "+"
+                      },
+                      {
+                          "class": "NumericTerm",
+                          "options": {},
+                          "evaluated": true,
+                          "number": 2
+                      },
+                      {
+                          "class": "OperatorTerm",
+                          "options": {},
+                          "evaluated": true,
+                          "operator": "+"
+                      },
+                      {
+                          "class": "NumericTerm",
+                          "options": {},
+                          "evaluated": true,
+                          "number": 4
+                      },
+                      {
+                          "class": "OperatorTerm",
+                          "options": {},
+                          "evaluated": true,
+                          "operator": "+"
+                      },
+                      {
+                          "class": "NumericTerm",
+                          "options": {},
+                          "evaluated": true,
+                          "number": 6
+                      }
+                  ],
+                  "total": 12,
+                  "evaluated": true
+              },
+              "rollType": "attack"
+          }
+      ],
+      [
+          "damage",
+          {
+              "damageType": "fire",
+              "baseRoll": {
+                  "class": "Roll",
+                  "options": {},
+                  "dice": [],
+                  "formula": "3d10[fire]",
+                  "terms": [
+                      {
+                          "class": "Die",
+                          "options": {
+                              "flavor": "fire",
+                              "baseNumber": 3
+                          },
+                          "evaluated": true,
+                          "number": 3,
+                          "faces": 10,
+                          "modifiers": [],
+                          "results": [
+                              {
+                                  "result": 7,
+                                  "active": true
+                              },
+                              {
+                                  "result": 2,
+                                  "active": true
+                              },
+                              {
+                                  "result": 8,
+                                  "active": true
+                              }
+                          ]
+                      }
+                  ],
+                  "total": 21,
+                  "evaluated": true
+              },
+              "critRoll": null,
+              "versatile": false
+          }
+      ],
+      [
+          "footer",
+          {
+              "properties": [
+                  "Cantrip",
+                  "V, S",
+                  "1 Action",
+                  "1 Creature",
+                  "120 Feet"
+              ]
+          }
+      ]
+  ],
+  "templates": [
+      "<header class=\"card-header flexrow rsr-header\">\r\n\t<img src=\"icons/magic/light/beam-rays-orange.webp\" title=\"Fire Bolt\" width=\"36\" height=\"36\"/>\r\n\t<h3 class=\"item-name\">Fire Bolt</h3>\r\n</header>",
+      "    <div class=\"card-content br-text\"><p>You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn't being worn or carried.</p>\n<p>This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).</p></div>\r\n",
+      "<div class=\"card-content\" style=\"display: block;\"></div>\r\n",
+      "<div class=\"dice-roll rsr-dual\" data-id=\"3\" data-roll-state=\"single\" data-type=\"attack\">\r\n    <div class=\"rsr5e-roll-label\">Attack </div>\r\n    <div class=\"dice-result\">\r\n\t\t<div class=\"dice-formula dice-tooltip\">1d20 + 2 + 4 + 6</div>\r\n\t\t<div class=\"dice-row rsr-rolls\">\r\n\t\t\t<div class=\"tooltip dual-left dice-row-item\"><div class=\"dice-tooltip\">\r\n    <section class=\"tooltip-part\">\r\n        <div class=\"dice\">\r\n            <header class=\"part-header flexrow\">\r\n                <span class=\"part-formula\">1d20</span>\r\n                \r\n                <span class=\"part-total\">8</span>\r\n            </header>\r\n            <ol class=\"dice-rolls\">\r\n                <li class=\"roll die d20\">8</li>\r\n            </ol>\r\n        </div>\r\n    </section>\r\n</div>\r\n</div>\r\n\t\t</div>\r\n\t\t<div class=\"dice-row rsr-rolls\">\r\n\t\t\t<div class=\"tooltip dice-row-item\"><div class=\"dice-tooltip\">\r\n</div>\r\n</div>\r\n\t\t</div>\r\n\t\t<div class=\"dice-row rsr-totals\">\r\n\t\t\t<h4 class=\"dice-total dice-row-item rsr-base-die \">\r\n\t\t\t\t20<span class=\"die-icon \">8</span>\r\n\t\t\t</h4>\r\n\t\t</div>\r\n    </div>\r\n</div>",
+      "<div class=\"dice-roll rsr-dual\" data-id=\"4\"  data-type=\"damage\">\r\n    <div class=\"rsr5e-roll-label\">Damage - Fire</div>\r\n    <div class=\"dice-result\">\r\n\t\t<div class=\"dice-formula dice-tooltip\">3d10[fire]</div>\r\n\t\t<div class=\"dice-row tooltips\">\r\n\t\t\t\t<div class=\"tooltip dual-left dice-row-item\"><div class=\"dice-tooltip\">\r\n    <section class=\"tooltip-part\">\r\n        <div class=\"dice\">\r\n            <header class=\"part-header flexrow\">\r\n                <span class=\"part-formula\">3d10</span>\r\n                <span class=\"part-flavor\">fire</span>\r\n                <span class=\"part-total\">17</span>\r\n            </header>\r\n            <ol class=\"dice-rolls\">\r\n                <li class=\"roll die d10\">7</li>\r\n                <li class=\"roll die d10\">2</li>\r\n                <li class=\"roll die d10\">8</li>\r\n            </ol>\r\n        </div>\r\n    </section>\r\n</div>\r\n</div>\r\n\t\t</div>\r\n\t\t<div class=\"dice-row\">\r\n\t\t\t<h4 class=\"dice-total dice-row-item rsr-damage\" data-damageType=\"fire\">\r\n\t\t\t\t<div class=\"rsr-base-die inline rsr-base-damage \" data-value=\"17\">17</div>\r\n\t\t\t\t\r\n\t\t\t</h4>\r\n\t\t</div>\r\n\t\t\r\n    </div>\r\n</div>\r\n",
+      "<footer class=\"card-footer\">\r\n    <span>Cantrip</span>\r\n    <span>V, S</span>\r\n    <span>1 Action</span>\r\n    <span>1 Creature</span>\r\n    <span>120 Feet</span>\r\n</footer>"
+  ],
+  "processed": true,
+  "messageId": "d75gppsau45ypm2m"
+};
+/*
+const midiWorkflowDisadvantage: MidiQolWorkflow = {
+  id: "d75gppsau45ypm2m",
+  actor: {
+    id: "5H4YnyD6zf9vcJ3P",
+    type: "character",
+  },
+  isCritical: false,
+  isFumble: false,
+  attackRoll: {
+    total: 18,
+    options: {
+      advantageMode: -1,
+    },
+  },
+  workflowType: "test",
+  attackTotal: 12,
+  damageTotal: 21,
+  item: {
+    id: "itemId",
+    name: "Flame Tongue Greatsword",
+    link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+    type: "sword",
+    img: "itemImageUrl",
+    system: {
+      actionType: "mwak",
+    },
+  },
+  hitTargets: new Set([{}, {}]),
+  targets: [
+    {
+      id: "tokenId",
+      sheet: {
+        actor: {
+          name: "Acolyte",
+          system: {
+            attributes: {
+              ac: {
+                value: 10,
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      id: "tokenId2",
+      sheet: {
+        actor: {
+          name: "Troll",
+          system: {
+            attributes: {
+              ac: {
+                value: 8,
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+};
+
+const midiWorkflowNoDiceRoll: MidiQolWorkflow = {
+  id: "d75gppsau45ypm2m",
+  actor: {
+    id: "5H4YnyD6zf9vcJ3P",
+    type: "character",
+  },
+  isCritical: false,
+  isFumble: false,
+  workflowType: "test",
+  item: {
+    id: "itemId",
+    name: "Flame Tongue Greatsword",
+    link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+    type: "sword",
+    img: "itemImageUrl",
+    system: {
+      actionType: "mwak",
+    },
+  },
+  hitTargets: new Set([{}, {}]),
+  targets: [
+    {
+      id: "tokenId",
+      sheet: {
+        actor: {
+          name: "Acolyte",
+          system: {
+            attributes: {
+              ac: {
+                value: 10,
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+};
+
+const midiWorkflowNoDiceRollNpc: MidiQolWorkflow = {
+  id: "d75gppsau45ypm2m",
+  actor: {
+    id: "5H4YnyD6zf9vcJ3P",
+    type: "npc",
+  },
+  isCritical: false,
+  isFumble: false,
+  workflowType: "test",
+  item: {
+    id: "itemId",
+    name: "Flame Tongue Greatsword",
+    link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+    type: "sword",
+    img: "itemImageUrl",
+    system: {
+      actionType: "mwak",
+    },
+  },
+  hitTargets: new Set([{}, {}]),
+  targets: [
+    {
+      id: "tokenId",
+      sheet: {
+        actor: {
+          name: "Acolyte",
+          system: {
+            attributes: {
+              ac: {
+                value: 10,
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+};*/
+
+describe("ReadySetRoll", () => {
+  describe("ParseWorkflow", () => {
+    describe("If it has a attack and damage roll", () => {
+      test("it returns the correct EncounterMidiWorkflow", async () => {
+        const result: EncounterWorkflow = ReadySetRoll.ParseWorkflow(readySetRollWorkflow);
+        expect(result).toStrictEqual(<EncounterWorkflow>{
+          id: "d75gppsau45ypm2m",
+          actionType: "mwak",
+          actor: {
+            id: "5H4YnyD6zf9vcJ3P",
+          },
+          advantage: true,
+          isCritical: false,
+          isFumble: false,
+          disadvantage: false,
+          attackTotal: 12,
+          diceTotal: 12,
+          damageTotal: 21,
+          item: {
+            id: "itemId",
+            name: "Flame Tongue Greatsword",
+            link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+            type: "sword",
+            img: "itemImageUrl",
+          },
+          enemyHit: [],
+          type: CombatDetailType.ReadySetRoll,
+        });
+      });
+    });
+/*
+    describe("If it has a attack and damage roll with disadvantage", () => {
+      test("it returns the correct EncounterMidiWorkflow", async () => {
+        const result: EncounterWorkflow = ReadySetRoll.ParseWorkflow(midiWorkflowDisadvantage);
+        expect(result).toStrictEqual(<EncounterWorkflow>{
+          id: "d75gppsau45ypm2m",
+          actionType: "mwak",
+          actor: {
+            id: "5H4YnyD6zf9vcJ3P",
+          },
+          advantage: false,
+          isCritical: false,
+          isFumble: false,
+          disadvantage: true,
+          diceTotal: undefined,
+          damageMultipleEnemiesTotal: 42,
+          workflowType: "test",
+          attackTotal: 12,
+          damageTotal: 21,
+          item: {
+            id: "itemId",
+            name: "Flame Tongue Greatsword",
+            link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+            type: "sword",
+            img: "itemImageUrl",
+          },
+          enemyHit: [
+            {
+              name: "Acolyte",
+              tokenId: "tokenId",
+            },
+            {
+              name: "Troll",
+              tokenId: "tokenId2",
+            },
+          ],
+          type: CombatDetailType.MidiQol,
+        });
+      });
+    });
+
+    describe("If it has no attack and damage roll", () => {
+      test("it returns the correct EncounterMidiWorkflow", async () => {
+        const result: EncounterWorkflow = ReadySetRoll.ParseWorkflow(
+          midiWorkflowNoDiceRoll
+        );
+        expect(result).toStrictEqual(<EncounterWorkflow>{
+          id: "d75gppsau45ypm2m",
+          actionType: "mwak",
+          actor: {
+            id: "5H4YnyD6zf9vcJ3P",
+          },
+          advantage: false,
+          isCritical: false,
+          isFumble: false,
+          diceTotal: undefined,
+          disadvantage: false,
+          damageMultipleEnemiesTotal: 0,
+          workflowType: "test",
+          attackTotal: 0,
+          damageTotal: 0,
+          item: {
+            id: "itemId",
+            name: "Flame Tongue Greatsword",
+            link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+            type: "sword",
+            img: "itemImageUrl",
+          },
+          enemyHit: [
+            {
+              name: "Acolyte",
+              tokenId: "tokenId",
+            },
+          ],
+          type: CombatDetailType.MidiQol,
+        });
+      });
+    });
+  });
+*/
+  describe("RollCheck", () => {
+    describe("if the check contains a valid actorId", () => {
+      beforeEach(() => {
+        (global as any).game = {
+          actors: {
+            get: jest.fn().mockReturnValue({
+              id: "actorId",
+              name: "Actor Name",
+              type: "character",
+            }),
+          },
+        };
+      });
+
+      test("it returns the correct EncounterMidiWorkflow", async () => {
+        const result = ReadySetRoll.RollCheck(readySetRollWorkflow);
+        expect(result).toStrictEqual(<DiceTrackParse>{
+          isCritical: false,
+          isFumble: false,
+          flavor: "Flame Tongue Greatsword",
+          name: "Actor Name",
+        });
+      });
+    });
+
+    describe("if the check doesn't contain a valid actorId", () => {
+      beforeEach(() => {
+        (global as any).game = {
+          actors: {
+            get: jest.fn().mockReturnValue(undefined),
+          },
+        };
+      });
+
+      test("it returns the correct EncounterMidiWorkflow", async () => {
+        const result = ReadySetRoll.RollCheck(readySetRollWorkflow);
+        expect(result).toBeUndefined();
+      });
+    });
+/*
+    describe("if its an npc", () => {
+      beforeEach(() => {
+        (global as any).game = {
+          actors: {
+            get: jest.fn().mockReturnValue({
+              id: "5H4YnyD6zf9vcJ3P",
+              type: "npc",
+            }),
+          },
+        };
+      });
+
+      test("it should return undefined", async () => {
+        const result = ReadySetRoll.RollCheck(midiWorkflowNoDiceRollNpc);
+        expect(result).toBeUndefined();
+      });
+    });*/
+  });
+});

--- a/scripts/parsers/ReadySetRoll.ts
+++ b/scripts/parsers/ReadySetRoll.ts
@@ -1,0 +1,72 @@
+import { EncounterWorkflow } from "EncounterWorkflow";
+import { CombatDetailType } from "../enums";
+import Logger from "../Helpers/Logger";
+
+class ReadySetRoll {
+  static ParseWorkflow(workflow: ReadySetRollWorkflow): EncounterWorkflow {
+    const enemiesHit: Array<EnemyHit> = []; /*workflow.targets.map(
+      (m) =>
+        <EnemyHit>{
+          tokenId: m.id,
+          name: m.sheet.actor.name,
+        }
+    );*/
+
+    const attackData = workflow.fields.find((f) => f[0] === "attack");
+    const damageData = workflow.fields.find((f) => f[0] === "damage");
+
+    return <EncounterWorkflow>{
+      id: workflow.messageId,
+      actor: {
+        id: workflow.actorId,
+      },
+      item: {
+        id: workflow.item.id,
+        name: workflow.item.name,
+        link: workflow.item.link,
+        type: workflow.item.type,
+        img: workflow.item.img,
+      },
+      actionType: workflow.item.system.actionType,
+      damageTotal: damageData ? damageData[1].baseRoll?.total : 0,
+      attackTotal: attackData ? attackData[1].roll?.total : 0,
+      advantage: workflow.params.hasAdvantage,
+      disadvantage: workflow.params.hasDisadvantage,
+      isCritical: workflow.params.isCrit,
+      isFumble: workflow.params.isFumble,
+      enemyHit: enemiesHit,
+      type: CombatDetailType.ReadySetRoll,
+      diceTotal: attackData ? attackData[1].roll?.total : undefined,
+    };
+  }
+
+  static RollCheck(workflow: ReadySetRollWorkflow): DiceTrackParse | undefined {
+    const actorId = workflow.actorId;
+
+    if (actorId) {
+      const actor = game.actors?.get(actorId);
+
+      if (!actor) {
+        Logger.log(
+          `No actor found for actorId ${actorId}`,
+          "rsr5e.rollProcessed",
+          workflow
+        );
+        return;
+      }
+
+      if (actor.type !== "character") {
+        return;
+      }
+
+      return <DiceTrackParse>{
+        isCritical: workflow.params.isCrit,
+        isFumble: workflow.params.isFumble,
+        flavor: workflow.item.name,
+        name: actor.name,
+      };
+    }
+  }
+}
+
+export default ReadySetRoll;

--- a/scripts/parsers/ReadySetRoll.ts
+++ b/scripts/parsers/ReadySetRoll.ts
@@ -4,12 +4,16 @@ import Logger from "../Helpers/Logger";
 
 class ReadySetRoll {
   static ParseRollData(workflow: ReadySetRollWorkflow): ReadySetRollRollData {
+    //const regRollResult = /(\d+).*/g;
     const attackData = workflow.fields.find((f) => f[0] === "attack");
     const damageData = workflow.fields.find((f) => f[0] === "damage");
-
+    /*const rollResult = parseInt(
+      attackData[1].roll?.result.replace(regRollResult, "$1")
+    );*/
     return {
       attackData: attackData,
       damageData: damageData,
+      //rollResult: rollResult,
     };
   }
 
@@ -47,9 +51,7 @@ class ReadySetRoll {
       isFumble: workflow.params.isFumble,
       enemyHit: enemiesHit,
       type: CombatDetailType.ReadySetRoll,
-      diceTotal: rollData.attackData
-        ? rollData.attackData[1].roll?.total
-        : undefined,
+      diceTotal: undefined,
     };
   }
 

--- a/scripts/parsers/ReadySetRoll.ts
+++ b/scripts/parsers/ReadySetRoll.ts
@@ -3,6 +3,16 @@ import { CombatDetailType } from "../enums";
 import Logger from "../Helpers/Logger";
 
 class ReadySetRoll {
+  static ParseRollData(workflow: ReadySetRollWorkflow): ReadySetRollRollData {
+    const attackData = workflow.fields.find((f) => f[0] === "attack");
+    const damageData = workflow.fields.find((f) => f[0] === "damage");
+
+    return {
+      attackData: attackData,
+      damageData: damageData,
+    };
+  }
+
   static ParseWorkflow(workflow: ReadySetRollWorkflow): EncounterWorkflow {
     const enemiesHit: Array<EnemyHit> = []; /*workflow.targets.map(
       (m) =>
@@ -12,8 +22,7 @@ class ReadySetRoll {
         }
     );*/
 
-    const attackData = workflow.fields.find((f) => f[0] === "attack");
-    const damageData = workflow.fields.find((f) => f[0] === "damage");
+    const rollData = this.ParseRollData(workflow);
 
     return <EncounterWorkflow>{
       id: workflow.messageId,
@@ -28,15 +37,19 @@ class ReadySetRoll {
         img: workflow.item.img,
       },
       actionType: workflow.item.system.actionType,
-      damageTotal: damageData ? damageData[1].baseRoll?.total : 0,
-      attackTotal: attackData ? attackData[1].roll?.total : 0,
+      damageTotal: rollData.damageData
+        ? rollData.damageData[1].baseRoll?.total
+        : 0,
+      attackTotal: rollData.attackData ? rollData.attackData[1].roll?.total : 0,
       advantage: workflow.params.hasAdvantage,
       disadvantage: workflow.params.hasDisadvantage,
       isCritical: workflow.params.isCrit,
       isFumble: workflow.params.isFumble,
       enemyHit: enemiesHit,
       type: CombatDetailType.ReadySetRoll,
-      diceTotal: attackData ? attackData[1].roll?.total : undefined,
+      diceTotal: rollData.attackData
+        ? rollData.attackData[1].roll?.total
+        : undefined,
     };
   }
 

--- a/scripts/parsers/ReadySetRoll.ts
+++ b/scripts/parsers/ReadySetRoll.ts
@@ -4,27 +4,16 @@ import Logger from "../Helpers/Logger";
 
 class ReadySetRoll {
   static ParseRollData(workflow: ReadySetRollWorkflow): ReadySetRollRollData {
-    //const regRollResult = /(\d+).*/g;
     const attackData = workflow.fields.find((f) => f[0] === "attack");
     const damageData = workflow.fields.find((f) => f[0] === "damage");
-    /*const rollResult = parseInt(
-      attackData[1].roll?.result.replace(regRollResult, "$1")
-    );*/
     return {
       attackData: attackData,
       damageData: damageData,
-      //rollResult: rollResult,
     };
   }
 
   static ParseWorkflow(workflow: ReadySetRollWorkflow): EncounterWorkflow {
-    const enemiesHit: Array<EnemyHit> = []; /*workflow.targets.map(
-      (m) =>
-        <EnemyHit>{
-          tokenId: m.id,
-          name: m.sheet.actor.name,
-        }
-    );*/
+    const enemiesHit: Array<EnemyHit> = [];
 
     const rollData = this.ParseRollData(workflow);
 

--- a/scripts/stats/ReadySetRollStat.test.ts
+++ b/scripts/stats/ReadySetRollStat.test.ts
@@ -1,0 +1,200 @@
+import ReadySetRollStat from "./ReadySetRollStat";
+import Logger from "../Helpers/Logger";
+jest.mock("../StatManager");
+import { actor } from "../mockdata/actor";
+import { CombatDetailType } from "../enums";
+
+const mockLoggerLog = jest.fn();
+const mockLoggerWarn = jest.fn();
+const mockLoggerError = jest.fn();
+Logger.log = mockLoggerLog;
+Logger.warn = mockLoggerWarn;
+Logger.error = mockLoggerError;
+
+const encounterReadySetRollWorkflow: EncounterWorkflow = {
+  id: "d75gppsau45ypm2m",
+  actionType: "mwak",
+  actor: {
+    id: "eMyoELkOwFNPGEK8",
+  },
+  advantage: true,
+  isCritical: false,
+  isFumble: false,
+  disadvantage: false,
+  damageMultipleEnemiesTotal: 0,
+  workflowType: "test",
+  attackTotal: 12,
+  damageTotal: 20,
+  item: {
+    id: "itemId",
+    name: "Flame Tongue Greatsword",
+    link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+    type: "sword",
+    img: "itemImageUrl",
+  },
+  enemyHit: [
+    {
+      name: "Acolyte",
+      tokenId: "tokenId",
+    },
+  ],
+  type: CombatDetailType.MidiQol,
+};
+
+const encounterReadySetRollWorkflow2: EncounterWorkflow = {
+  id: "d75gppsau45ypm2b",
+  actionType: "mwak",
+  actor: {
+    id: "eMyoELkOwFNPGEK8",
+  },
+  advantage: true,
+  isCritical: false,
+  isFumble: false,
+  disadvantage: false,
+  damageMultipleEnemiesTotal: 0,
+  workflowType: "test",
+  attackTotal: 12,
+  damageTotal: 15,
+  item: {
+    id: "itemId",
+    name: "Flame Tongue Greatsword",
+    link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+    type: "sword",
+    img: "itemImageUrl",
+  },
+  enemyHit: [
+    {
+      name: "Acolyte",
+      tokenId: "tokenId",
+    },
+  ],
+  type: CombatDetailType.MidiQol,
+};
+
+const encounterReadySetRollWorkflowHeal: EncounterWorkflow = {
+  id: "d75gppsau45ypm2c",
+  actionType: "heal",
+  actor: {
+    id: "eMyoELkOwFNPGEK8",
+  },
+  advantage: true,
+  isCritical: false,
+  isFumble: false,
+  disadvantage: false,
+  damageMultipleEnemiesTotal: 0,
+  workflowType: "test",
+  attackTotal: 12,
+  damageTotal: 15,
+  item: {
+    id: "itemId",
+    name: "Flame Tongue Greatsword",
+    link: "@Compendium[dnd5e.items.WWb4vAmh18sMAxfY]{Flame Tongue Greatsword}",
+    type: "sword",
+    img: "itemImageUrl",
+  },
+  type: CombatDetailType.MidiQol,
+};
+
+describe("ReadySetRollStat", () => {
+  let midiQolStat: ReadySetRollStat;
+  const encounterId = "encounterId";
+  beforeEach(() => {
+    (global as any).canvas = {
+      tokens: {
+        get: jest.fn().mockReturnValue({
+          img: "testImageUrl",
+        }),
+      },
+    };
+    midiQolStat = new ReadySetRollStat(encounterId);
+  });
+  describe("If you add a new Attack", () => {
+
+    test("and it has a missing actor id", async () => {
+      await midiQolStat.AddCombatant(actor, "tokenId", 12);
+      midiQolStat.AddAttack({ actor: {} });
+      midiQolStat.Save();
+      expect(mockLoggerError).toHaveBeenCalled();
+    });
+    test("and actor does not match the combatant", async () => {
+      await midiQolStat.AddCombatant(actor, "tokenId", 13);
+      midiQolStat.AddAttack({ actor: { id: "wrongId" } });
+      midiQolStat.Save();
+      expect(mockLoggerError).toHaveBeenCalled();
+    });
+    test("the initial midiQolStats all return 0", async () => {
+      await midiQolStat.AddCombatant(actor, "tokenId", 14);
+      midiQolStat.Save();
+      expect(midiQolStat.encounter.combatants.length).toBe(1);
+      const combatantResult = midiQolStat.GetCombatantStats("eMyoELkOwFNPGEK8");
+
+      expect(midiQolStat.encounter.combatants.length).toBe(1);
+      expect(combatantResult?.events.length).toBe(0);
+
+      expect(midiQolStat.encounter.top.maxDamage).toBe("None<br />0");
+      expect(midiQolStat.encounter.top.mostDamageInOneTurn).toBe("None<br />0");
+      expect(midiQolStat.encounter.top.highestAvgDamage).toBe("None<br />0");
+      expect(midiQolStat.encounter.top.highestMaxDamage).toBe("None<br />0");
+      expect(midiQolStat.encounter.top.mostKills).toBe("None<br />0");
+      expect(midiQolStat.encounter.top.mostHealing).toBe("None<br />0");
+      expect(midiQolStat.encounter.top.mostSupportActions).toBe("None<br />0");
+      expect(midiQolStat.encounter.top.mostBattlefieldActions).toBe(
+        "None<br />0"
+      );
+
+      expect(combatantResult?.summaryList).toStrictEqual(<
+        CombatantEventSummaryList
+      >{ min: 0, max: 0, avg: 0, total: 0 });
+      expect(combatantResult?.roundSummary).toStrictEqual(<
+        EncounterRoundSummary
+      >{
+        totals: [],
+      });
+    });
+    test("you can get the combatant by actor id", async () => {
+      await midiQolStat.AddCombatant(actor, "tokenId", 1);
+      midiQolStat.AddAttack(encounterReadySetRollWorkflow);
+      midiQolStat.AddAttack(encounterReadySetRollWorkflow2);
+      midiQolStat.AddAttack(encounterReadySetRollWorkflowHeal);
+      midiQolStat.AddKill("Acolyte", "tokenId");
+      midiQolStat.Save();
+      expect(midiQolStat.encounter.combatants.length).toBe(1);
+      const combatantResult = midiQolStat.GetCombatantStats("eMyoELkOwFNPGEK8");
+      expect(midiQolStat.encounter.combatants.length).toBe(1);
+      expect(combatantResult?.events.length).toBe(3);
+
+      expect(midiQolStat.encounter.top.maxDamage).toBe("Graa S'oua<br />35");
+      expect(midiQolStat.encounter.top.mostDamageInOneTurn).toBe(
+        "Graa S'oua<br />35"
+      );
+      expect(midiQolStat.encounter.top.highestAvgDamage).toBe(
+        "Graa S'oua<br />18"
+      );
+      expect(midiQolStat.encounter.top.highestMaxDamage).toBe(
+        "Graa S'oua<br />20"
+      );
+      expect(midiQolStat.encounter.top.mostKills).toBe("Graa S'oua<br />1");
+      expect(midiQolStat.encounter.top.mostHealing).toBe("Graa S'oua<br />1");
+      expect(midiQolStat.encounter.top.mostSupportActions).toBe(
+        "Graa S'oua<br />1"
+      );
+      expect(midiQolStat.encounter.top.mostBattlefieldActions).toBe(
+        "Graa S'oua<br />0"
+      );
+
+      expect(combatantResult?.summaryList).toStrictEqual(<
+        CombatantEventSummaryList
+      >{ min: 15, max: 20, avg: 18, total: 35 });
+      expect(combatantResult?.roundSummary).toStrictEqual(<
+        EncounterRoundSummary
+      >{
+        totals: [
+          {
+            round: 1,
+            damageTotal: 35,
+          },
+        ],
+      });
+    });
+  });
+});

--- a/scripts/stats/ReadySetRollStat.ts
+++ b/scripts/stats/ReadySetRollStat.ts
@@ -1,5 +1,4 @@
 import Logger from "../Helpers/Logger";
-import StatManager from "../StatManager";
 import Stat from "./Stat";
 
 export default class ReadySetRollStat extends Stat {

--- a/scripts/stats/ReadySetRollStat.ts
+++ b/scripts/stats/ReadySetRollStat.ts
@@ -3,21 +3,23 @@ import StatManager from "../StatManager";
 import Stat from "./Stat";
 
 export default class ReadySetRollStat extends Stat {
-  async UpdateDamageForLastAttack(tokenId: string, damage: number) {
+  /*async UpdateDamageForLastAttack(tokenId: string, damage: number) {
     const stat = new Stat();
     stat.encounter = await StatManager.GetStat();
     const combatantStat = stat.GetCombatantStatsByTokenId(tokenId);
     if (combatantStat?.events?.length ?? 0 > 0) {
       const lastStat = combatantStat.events[combatantStat.events.length - 1];
       const lastDamageValue = lastStat.damageMultipleEnemiesTotal ?? 0;
+      console.log("encstat before", lastStat.damageMultipleEnemiesTotal)
       lastStat.damageMultipleEnemiesTotal = lastDamageValue + Math.abs(damage);
+      console.log("encstat after", lastStat.damageMultipleEnemiesTotal)
     }
 
     // TODO:
     // 1: Not updating multiple times, race condition of the events?
 
     await stat.Save();
-  }
+  }*/
 
   AddAttack(workflow: EncounterWorkflow) {
     if (!workflow?.actor?.id) {

--- a/scripts/stats/ReadySetRollStat.ts
+++ b/scripts/stats/ReadySetRollStat.ts
@@ -1,8 +1,9 @@
 import Logger from "../Helpers/Logger";
+import StatManager from "../StatManager";
 import Stat from "./Stat";
 
 export default class ReadySetRollStat extends Stat {
-  /*async UpdateDamageForLastAttack(tokenId: string, damage: number) {
+  async UpdateDamageForLastAttack(tokenId: string, damage: number) {
     const stat = new Stat();
     stat.encounter = await StatManager.GetStat();
     const combatantStat = stat.GetCombatantStatsByTokenId(tokenId);
@@ -14,11 +15,8 @@ export default class ReadySetRollStat extends Stat {
       console.log("encstat after", lastStat.damageMultipleEnemiesTotal)
     }
 
-    // TODO:
-    // 1: Not updating multiple times, race condition of the events?
-
     await stat.Save();
-  }*/
+  }
 
   AddAttack(workflow: EncounterWorkflow) {
     if (!workflow?.actor?.id) {

--- a/scripts/stats/ReadySetRollStat.ts
+++ b/scripts/stats/ReadySetRollStat.ts
@@ -7,11 +7,14 @@ export default class ReadySetRollStat extends Stat {
     const stat = new Stat();
     stat.encounter = await StatManager.GetStat();
     const combatantStat = stat.GetCombatantStatsByTokenId(tokenId);
-    if (combatantStat.events.length > 0) {
+    if (combatantStat?.events?.length ?? 0 > 0) {
       const lastStat = combatantStat.events[combatantStat.events.length - 1];
       const lastDamageValue = lastStat.damageMultipleEnemiesTotal ?? 0;
-      lastStat.damageMultipleEnemiesTotal = lastDamageValue + damage;
+      lastStat.damageMultipleEnemiesTotal = lastDamageValue + Math.abs(damage);
     }
+
+    // TODO:
+    // 1: Not updating multiple times, race condition of the events?
 
     await stat.Save();
   }
@@ -33,35 +36,53 @@ export default class ReadySetRollStat extends Stat {
       );
       return;
     }
+    const lastCombatantEvent =
+      combatantStat.events[combatantStat.events.length - 1];
 
-    const newCombatantEvent = <CombatantEvent>{
-      id: workflow.id,
-      actorId: workflow.actor.id,
-      item: workflow.item,
-      advantage: workflow.advantage,
-      disadvantage: workflow.disadvantage,
-      actionType: workflow.actionType,
-      round: this.currentRound,
-      enemyHit: workflow.enemyHit,
-      attackTotal: 0,
-      damageTotal: 0,
-      damageMultipleEnemiesTotal: 0,
-      isCritical: false,
-    };
+    const isExistingEvent: boolean =
+      lastCombatantEvent !== undefined &&
+      lastCombatantEvent.damageTotal !== undefined &&
+      lastCombatantEvent.damageTotal === 0 &&
+      workflow.damageTotal > 0 &&
+      lastCombatantEvent.actorId === workflow.actor.id &&
+      lastCombatantEvent.round === this.currentRound &&
+      lastCombatantEvent.item?.id === workflow.item.id;
 
-    if (this.IsValidAttack(newCombatantEvent.actionType)) {
-      if (workflow.attackTotal) {
-        newCombatantEvent.attackTotal = workflow.attackTotal;
+    if (isExistingEvent) {
+      const newCombatantEvent =
+        combatantStat.events[combatantStat.events.length - 1];
+
+      newCombatantEvent.damageTotal = workflow.damageTotal;
+    } else {
+      const newCombatantEvent = <CombatantEvent>{
+        id: workflow.id,
+        actorId: workflow.actor.id,
+        item: workflow.item,
+        advantage: workflow.advantage,
+        disadvantage: workflow.disadvantage,
+        actionType: workflow.actionType,
+        round: this.currentRound,
+        enemyHit: workflow.enemyHit,
+        attackTotal: 0,
+        damageTotal: 0,
+        damageMultipleEnemiesTotal: 0,
+        isCritical: false,
+      };
+
+      if (this.IsValidAttack(newCombatantEvent.actionType)) {
+        if (workflow.attackTotal) {
+          newCombatantEvent.attackTotal = workflow.attackTotal;
+        }
       }
-    }
-    if (this.IsValidRollEvent(newCombatantEvent.actionType)) {
-      if (workflow.damageTotal) {
-        newCombatantEvent.damageMultipleEnemiesTotal =
-          workflow.damageMultipleEnemiesTotal;
-        newCombatantEvent.damageTotal = workflow.damageTotal;
-        newCombatantEvent.isCritical = workflow.isCritical;
+      if (this.IsValidRollEvent(newCombatantEvent.actionType)) {
+        if (workflow.damageTotal) {
+          newCombatantEvent.damageMultipleEnemiesTotal =
+            workflow.damageMultipleEnemiesTotal;
+          newCombatantEvent.damageTotal = workflow.damageTotal;
+          newCombatantEvent.isCritical = workflow.isCritical;
+        }
       }
+      combatantStat.events.push(newCombatantEvent);
     }
-    combatantStat.events.push(newCombatantEvent);
   }
 }

--- a/scripts/stats/ReadySetRollStat.ts
+++ b/scripts/stats/ReadySetRollStat.ts
@@ -1,7 +1,21 @@
 import Logger from "../Helpers/Logger";
+import StatManager from "../StatManager";
 import Stat from "./Stat";
 
 export default class ReadySetRollStat extends Stat {
+  async UpdateDamageForLastAttack(tokenId: string, damage: number) {
+    const stat = new Stat();
+    stat.encounter = await StatManager.GetStat();
+    const combatantStat = stat.GetCombatantStatsByTokenId(tokenId);
+    if (combatantStat.events.length > 0) {
+      const lastStat = combatantStat.events[combatantStat.events.length - 1];
+      const lastDamageValue = lastStat.damageMultipleEnemiesTotal ?? 0;
+      lastStat.damageMultipleEnemiesTotal = lastDamageValue + damage;
+    }
+
+    await stat.Save();
+  }
+
   AddAttack(workflow: EncounterWorkflow) {
     if (!workflow?.actor?.id) {
       Logger.error(`No Actor ID in encounter`, "rsr5e.rollProcessed", workflow);

--- a/scripts/stats/ReadySetRollStat.ts
+++ b/scripts/stats/ReadySetRollStat.ts
@@ -1,0 +1,53 @@
+import Logger from "../Helpers/Logger";
+import Stat from "./Stat";
+
+export default class ReadySetRollStat extends Stat {
+  AddAttack(workflow: EncounterWorkflow) {
+    if (!workflow?.actor?.id) {
+      Logger.error(`No Actor ID in encounter`, "rsr5e.rollProcessed", workflow);
+      return;
+    }
+
+    const combatantStat: EncounterCombatant | undefined =
+      this.GetCombatantStats(workflow.actor.id);
+
+    if (!combatantStat) {
+      Logger.log(
+        `No combatant found for Actor ID ${workflow.actor.id}`,
+        "rsr5e.rollProcessed",
+        workflow
+      );
+      return;
+    }
+
+    const newCombatantEvent = <CombatantEvent>{
+      id: workflow.id,
+      actorId: workflow.actor.id,
+      item: workflow.item,
+      advantage: workflow.advantage,
+      disadvantage: workflow.disadvantage,
+      actionType: workflow.actionType,
+      round: this.currentRound,
+      enemyHit: workflow.enemyHit,
+      attackTotal: 0,
+      damageTotal: 0,
+      damageMultipleEnemiesTotal: 0,
+      isCritical: false,
+    };
+
+    if (this.IsValidAttack(newCombatantEvent.actionType)) {
+      if (workflow.attackTotal) {
+        newCombatantEvent.attackTotal = workflow.attackTotal;
+      }
+    }
+    if (this.IsValidRollEvent(newCombatantEvent.actionType)) {
+      if (workflow.damageTotal) {
+        newCombatantEvent.damageMultipleEnemiesTotal =
+          workflow.damageMultipleEnemiesTotal;
+        newCombatantEvent.damageTotal = workflow.damageTotal;
+        newCombatantEvent.isCritical = workflow.isCritical;
+      }
+    }
+    combatantStat.events.push(newCombatantEvent);
+  }
+}

--- a/scripts/stats/ReadySetRollStat.ts
+++ b/scripts/stats/ReadySetRollStat.ts
@@ -1,23 +1,7 @@
 import Logger from "../Helpers/Logger";
-import StatManager from "../StatManager";
 import Stat from "./Stat";
 
 export default class ReadySetRollStat extends Stat {
-  async UpdateDamageForLastAttack(tokenId: string, damage: number) {
-    const stat = new Stat();
-    stat.encounter = await StatManager.GetStat();
-    const combatantStat = stat.GetCombatantStatsByTokenId(tokenId);
-    if (combatantStat?.events?.length ?? 0 > 0) {
-      const lastStat = combatantStat.events[combatantStat.events.length - 1];
-      const lastDamageValue = lastStat.damageMultipleEnemiesTotal ?? 0;
-      console.log("encstat before", lastStat.damageMultipleEnemiesTotal)
-      lastStat.damageMultipleEnemiesTotal = lastDamageValue + Math.abs(damage);
-      console.log("encstat after", lastStat.damageMultipleEnemiesTotal)
-    }
-
-    await stat.Save();
-  }
-
   AddAttack(workflow: EncounterWorkflow) {
     if (!workflow?.actor?.id) {
       Logger.error(`No Actor ID in encounter`, "rsr5e.rollProcessed", workflow);

--- a/scripts/types/ReadySetRollWorkflow.d.ts
+++ b/scripts/types/ReadySetRollWorkflow.d.ts
@@ -64,3 +64,8 @@ interface ReadySetRollEventItem {
     actionType: string;
   };
 }
+
+interface ReadySetRollRollData {
+  attackData: unknown;
+  damageData: unknown;
+}

--- a/scripts/types/ReadySetRollWorkflow.d.ts
+++ b/scripts/types/ReadySetRollWorkflow.d.ts
@@ -1,0 +1,66 @@
+interface ReadySetRollWorkflow {
+  messageId: string;
+  itemId: string;
+  actorId: string;
+  tokenId: string;
+  actor: {
+    id: string;
+  };
+  item: ReadySetRollEventItem;
+  params: {
+    hasAdvantage: boolean;
+    hasDisadvantage: boolean;
+    isCrit: boolean;
+    isFumble: boolean;
+    isMultiRoll: boolean;
+    isAltRoll: boolean;
+    elvenAccuracy: boolean;
+    slotLevel: number;
+    spellLevel: number;
+  };
+  fields: [
+    [
+      header: {
+        title: string;
+        slotLevel: number;
+      }
+    ],
+    [
+      description: {
+        content: string;
+      }
+    ],
+    [
+      blank: {
+        display: boolean;
+      }
+    ],
+    [
+      attack: {
+        roll: {
+          total: number;
+        };
+      }
+    ],
+    [
+      damage: {
+        baseRoll: {
+          total: number;
+        };
+      }
+    ]
+  ];
+  processed: boolean;
+  messageId: string;
+}
+
+interface ReadySetRollEventItem {
+  id: string;
+  name: string;
+  link: string;
+  type: string;
+  img: string;
+  system: {
+    actionType: string;
+  };
+}


### PR DESCRIPTION
# Description

Add support for tracking `Ready Set Roll for D&D5e` module.

## TODO

- [x] Add more tests for various rolls
- [x] Explore various module settings to cover edge cases and add tests
- [x] Implement manual damage button logic
- [x] If apply damage, use this instead of item damage

Fixes #461 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update