### PR TITLE
612 roll streaks chat cards spoil blind gm rolls

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -11,6 +11,8 @@
     "EncounterStats.opt_enable_dice_streak_hint": "Track the number of times a player rolls the same result on a D20.",
     "EncounterStats.opt_enable_dice_streak_to_chat_name": "Track Dice Streaks Chat Message",
     "EncounterStats.opt_enable_dice_streak_to_chat_hint": "Show a message in Chat when a player rolls the same result on a D20.",
+    "EncounterStats.opt_enable_dice_streak_threshold_name": "Dice Streak threshold to track",
+    "EncounterStats.opt_enable_dice_streak_threshold_hint": "Set the number pf consecutive dice rolls to alert for a streak.",
     "EncounterStats.template.most_damage_overall": "Most Damage Overall",
     "EncounterStats.template.most_damage_per_turn": "Most Damage in 1 turn",
     "EncounterStats.template.highest_average_damage": "Highest Average Damage",

--- a/scripts/CampaignRenderer.test.ts
+++ b/scripts/CampaignRenderer.test.ts
@@ -21,22 +21,18 @@ describe("CampaignRenderer", () => {
 
       expect(result.nat1).toStrictEqual([
         { name: "Fighter", value: 7 },
-        { name: "Orc", value: 1 },
-        { name: "Lorena Aldabra", value: 1 },
+        { name: "Orc & Lorena Aldabra", value: 1 },
       ]);
 
       expect(result.nat20).toStrictEqual([
         { name: "Fighter", value: 3 },
-        { name: "Orc", value: 1 },
-        { name: "Lorena Aldabra", value: 1 },
+        { name: "Orc & Lorena Aldabra", value: 1 },
       ]);
 
-      expect(result.heals).toStrictEqual([{ name: "Graa", value: 1 }]);
+      expect(result.heals).toStrictEqual([{ name: "Graa", value: 2 }]);
 
       expect(result.kills).toStrictEqual([
-        { name: "Graa", value: 1 },
-        { name: "Lorena Aldabra", value: 1 },
-        { name: "Fighter", value: 1 },
+        { name: "Graa & Lorena Aldabra & Fighter", value: 1 },
       ]);
 
       expect(result.criticalHistory).toStrictEqual([
@@ -139,6 +135,13 @@ describe("CampaignRenderer", () => {
         {
           date: "30 September 2022",
           entries: [
+            {
+              actorName: "Graa",
+              flavor:
+                "@UUID[Actor.2ybHnw0DeYqwDPyV.Item.yAmmCAv5PSEM8X5f]{Potion of Healing (Greater)}",
+              date: "30 September 2022 20:03",
+              total: 15,
+            },
             {
               actorName: "Graa",
               flavor:

--- a/scripts/CampaignRenderer.ts
+++ b/scripts/CampaignRenderer.ts
@@ -221,7 +221,12 @@ class CampaignRenderer {
     });
 
     result.forEach((entry) => {
-      data.push({ name: entry.name, value: entry.value });
+      const existingValue = data.find(({ value }) => value === entry.value);
+      if (existingValue) {
+        existingValue.name = existingValue.name + " & " + entry.name;
+      } else {
+        data.push({ name: entry.name, value: entry.value });
+      }
     });
 
     return data;

--- a/scripts/CampaignStat.test.ts
+++ b/scripts/CampaignStat.test.ts
@@ -45,7 +45,11 @@ describe("CampaignStat", () => {
           format: jest.fn().mockReturnValue("TestKeyValue"),
         },
         settings: {
-          get: jest.fn().mockReturnValue(true),
+          get: jest.fn()
+          .mockReturnValueOnce(true).mockReturnValueOnce("2")
+          .mockReturnValueOnce(true).mockReturnValueOnce("2").mockReturnValueOnce(true)
+          .mockReturnValueOnce(true).mockReturnValueOnce("2").mockReturnValueOnce(true)
+          .mockReturnValueOnce(true).mockReturnValueOnce("2").mockReturnValueOnce(true),
         },
       };
       mockGamemasterGetStats.mockReturnValue({
@@ -99,7 +103,11 @@ describe("CampaignStat", () => {
           format: jest.fn().mockReturnValue("TestKeyValue"),
         },
         settings: {
-          get: jest.fn().mockReturnValue(true),
+          get: jest.fn()
+          .mockReturnValueOnce(true).mockReturnValueOnce("2")
+          .mockReturnValueOnce(true).mockReturnValueOnce("2").mockReturnValueOnce(true)
+          .mockReturnValueOnce(true).mockReturnValueOnce("2").mockReturnValueOnce(true)
+          .mockReturnValueOnce(true).mockReturnValueOnce("2").mockReturnValueOnce(true),
         },
       };
       mockGamemasterGetStats.mockReturnValue({
@@ -135,7 +143,7 @@ describe("CampaignStat", () => {
       await CampaignStat.AddRollStreak(1, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.blindroll);
       expect(mockEncounterJournalUpdateJournalData).toBeCalled();
       expect(mock_sendRollStreakChatMessage).toBeCalled();
-      expect(mock_sendRollStreakChatMessage).toBeCalledTimes(4);
+      expect(mock_sendRollStreakChatMessage).toBeCalledTimes(3);
       expect(mockGamemasterSetStats).toBeCalled();
       expect(mockGamemasterSetStats).toBeCalledWith({
         kills: [],
@@ -150,19 +158,12 @@ describe("CampaignStat", () => {
             "dateDisplay": "01 November 2022",
             "roll": 4,
             "total": 3
-          },
-          {
-            "actorId": "2ybHnw0DeYqwDPyV",
-            "actorName": "Graa",
-            "dateDisplay": "01 January 2020",
-            "roll": 9,
-            "total": 5
           }
         ],
         rollstreaklog: [
           {
             actorId: "2ybHnw0DeYqwDPyV",
-            results: [1],
+            results: [9,9,9,9,9],
           },
         ],
       });

--- a/scripts/CampaignStat.test.ts
+++ b/scripts/CampaignStat.test.ts
@@ -1,7 +1,7 @@
 import CampaignRenderer from "./CampaignRenderer";
 import CampaignStat from "./CampaignStat";
 import EncounterJournal from "./EncounterJournal";
-import { RoleType } from "./enums";
+import { ChatRollMode, RoleType } from "./enums";
 import Gamemaster from "./Helpers/Gamemaster";
 import "../__mocks__/chat-message";
 
@@ -59,10 +59,10 @@ describe("CampaignStat", () => {
     });
 
     test("it adds the Roll Streak correctly", async () => {
-      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV");
-      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV");
-      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV");
-      await CampaignStat.AddRollStreak(1, "Graa", "2ybHnw0DeYqwDPyV");
+      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.publicroll);
+      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.publicroll);
+      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.publicroll);
+      await CampaignStat.AddRollStreak(1, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.publicroll);
       expect(mockEncounterJournalUpdateJournalData).toBeCalled();
       expect(mock_sendRollStreakChatMessage).toBeCalled();
       expect(mock_sendRollStreakChatMessage).toBeCalledTimes(2);
@@ -128,14 +128,14 @@ describe("CampaignStat", () => {
     });
 
     test("it adds the Roll Streak correctly", async () => {
-      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV");
-      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV");
-      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV");
-      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV");
-      await CampaignStat.AddRollStreak(1, "Graa", "2ybHnw0DeYqwDPyV");
+      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.publicroll);
+      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.publicroll);
+      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.blindroll);
+      await CampaignStat.AddRollStreak(9, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.blindroll);
+      await CampaignStat.AddRollStreak(1, "Graa", "2ybHnw0DeYqwDPyV", ChatRollMode.blindroll);
       expect(mockEncounterJournalUpdateJournalData).toBeCalled();
       expect(mock_sendRollStreakChatMessage).toBeCalled();
-      expect(mock_sendRollStreakChatMessage).toBeCalledTimes(6);
+      expect(mock_sendRollStreakChatMessage).toBeCalledTimes(4);
       expect(mockGamemasterSetStats).toBeCalled();
       expect(mockGamemasterSetStats).toBeCalledWith({
         kills: [],

--- a/scripts/CampaignStat.ts
+++ b/scripts/CampaignStat.ts
@@ -146,7 +146,7 @@ export default class CampaignStat {
             `${MODULE_ID}`,
             `${OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE}`,
           ) &&
-          chatRollMode === ChatRollMode.publicroll
+          chatRollMode === ChatRollMode.publicroll.valueOf()
         ) {
           this._sendRollStreakChatMessage(actorName, actorStreakLog);
         }

--- a/scripts/CampaignStat.ts
+++ b/scripts/CampaignStat.ts
@@ -1,7 +1,7 @@
 import CampaignRenderer from "./CampaignRenderer";
 import Chat from "./Chat";
 import EncounterJournal from "./EncounterJournal";
-import { RoleType } from "./enums";
+import { ChatRollMode, RoleType } from "./enums";
 import Dates from "./Helpers/Dates";
 import Gamemaster from "./Helpers/Gamemaster";
 import Trans from "./Helpers/Trans";
@@ -108,6 +108,7 @@ export default class CampaignStat {
     result: number,
     actorName: string,
     actorId: string,
+    chatRollMode: ChatRollMode,
   ) {
     if (
       !game.settings.get(`${MODULE_ID}`, `${OPT_SETTINGS_DICE_STREAK_ENABLE}`)
@@ -144,7 +145,8 @@ export default class CampaignStat {
           game.settings.get(
             `${MODULE_ID}`,
             `${OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE}`,
-          )
+          ) &&
+          chatRollMode === ChatRollMode.publicroll
         ) {
           this._sendRollStreakChatMessage(actorName, actorStreakLog);
         }

--- a/scripts/CampaignStat.ts
+++ b/scripts/CampaignStat.ts
@@ -8,6 +8,7 @@ import Trans from "./Helpers/Trans";
 import {
   MODULE_ID,
   OPT_SETTINGS_DICE_STREAK_ENABLE,
+  OPT_SETTINGS_DICE_STREAK_THRESHOLD,
   OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE,
 } from "./Settings";
 
@@ -116,6 +117,14 @@ export default class CampaignStat {
       return;
     }
 
+    const diceStreakThreshold: number = parseInt(
+      <string>(
+        game.settings.get(
+          `${MODULE_ID}`,
+          `${OPT_SETTINGS_DICE_STREAK_THRESHOLD}`,
+        )
+      ),
+    );
     const campaignStats = await this.Get();
     const date = Dates.now;
 
@@ -146,12 +155,13 @@ export default class CampaignStat {
             `${MODULE_ID}`,
             `${OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE}`,
           ) &&
-          chatRollMode === ChatRollMode.publicroll.valueOf()
+          chatRollMode === ChatRollMode.publicroll.valueOf() &&
+          actorStreakLog.length >= diceStreakThreshold
         ) {
           this._sendRollStreakChatMessage(actorName, actorStreakLog);
         }
       } else {
-        if (actorStreakLog.length > 1) {
+        if (actorStreakLog.length >= diceStreakThreshold) {
           // Save to streak length and result
           campaignStats.rollstreak.push(<RollStreakTrack>{
             actorId: actorId,

--- a/scripts/Handlers.ts
+++ b/scripts/Handlers.ts
@@ -4,7 +4,7 @@ import Stat from "./stats/Stat";
 import MidiQolStat from "./stats/MidiQolStat";
 import DND5eStat from "./stats/DND5eStat";
 import CampaignStat from "./CampaignStat";
-import { ChatType, RoleType } from "./enums";
+import { ChatRollMode, ChatType, RoleType } from "./enums";
 import Logger from "./Helpers/Logger";
 import { EncounterWorkflow } from "EncounterWorkflow";
 import PF2eStat from "./stats/PF2eStat";
@@ -18,10 +18,10 @@ export async function OnTrackRollStreak(
   result: number,
   actorName: string,
   actorId: string,
+  chatRollMode: ChatRollMode,
 ): Promise<void> {
   if (!result) return;
-
-  CampaignStat.AddRollStreak(result, actorName, actorId);
+  CampaignStat.AddRollStreak(result, actorName, actorId, chatRollMode);
 }
 
 export async function OnTrackDiceRoll(

--- a/scripts/ModuleSettings.ts
+++ b/scripts/ModuleSettings.ts
@@ -3,6 +3,7 @@ import {
   OPT_ENABLE,
   OPT_ENABLE_EXPORT_JSON,
   OPT_SETTINGS_DICE_STREAK_ENABLE,
+  OPT_SETTINGS_DICE_STREAK_THRESHOLD,
   OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE,
 } from "./Settings";
 import Trans from "./Helpers/Trans";
@@ -74,6 +75,19 @@ class ModuleSettings {
         config: false,
         default: true,
         type: Boolean,
+      },
+    );
+
+    game.settings.register(
+      `${MODULE_ID}`,
+      `${OPT_SETTINGS_DICE_STREAK_THRESHOLD}`,
+      {
+        name: Trans.Get("opt_enable_dice_streak_threshold_name"),
+        hint: Trans.Get("opt_enable_dice_streak_threshold_hint"),
+        scope: "world",
+        config: false,
+        default: "2",
+        type: String,
       },
     );
   }

--- a/scripts/Settings.ts
+++ b/scripts/Settings.ts
@@ -12,3 +12,4 @@ export const OPT_ENABLE_EXPORT_JSON = "enableExportJson";
 
 export const OPT_SETTINGS_DICE_STREAK_ENABLE = "enableDiceStreak";
 export const OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE = "enableDiceStreakToChat";
+export const OPT_SETTINGS_DICE_STREAK_THRESHOLD = "diceStreakThreshold";

--- a/scripts/SetupHooksDND5e.ts
+++ b/scripts/SetupHooksDND5e.ts
@@ -13,7 +13,7 @@ import {
 import StatManager from "./StatManager";
 import DND5e from "./parsers/DND5e";
 import MidiQol from "./parsers/MidiQol";
-import { CombatDetailType, ChatType } from "./enums";
+import { CombatDetailType, ChatType, ChatRollMode } from "./enums";
 import Stat from "./stats/Stat";
 import ReadySetRoll from "./parsers/ReadySetRoll";
 import { EncounterWorkflow } from "EncounterWorkflow";
@@ -72,6 +72,7 @@ export default class SetupHooksDND5e {
                 midiWorkflow.diceTotal,
                 rollCheck.tokenName ?? rollCheck.name,
                 midiWorkflow.actor.id,
+                ChatRollMode[game.settings.get("core", "rollMode")],
               );
             }
           },
@@ -124,6 +125,8 @@ export default class SetupHooksDND5e {
               data: {
                 workflow: MidiQol.ParseWorkflow(workflow),
                 rollCheck: MidiQol.RollCheck(workflow),
+                chatRollMode:
+                  ChatRollMode[game.settings.get("core", "rollMode")],
               },
             });
           },
@@ -182,6 +185,8 @@ export default class SetupHooksDND5e {
                   roll,
                 ),
                 ChatType: ChatType.DND5e,
+                chatRollMode:
+                  ChatRollMode[game.settings.get("core", "rollMode")],
               },
             });
           }
@@ -205,6 +210,8 @@ export default class SetupHooksDND5e {
                   roll,
                 ),
                 ChatType: ChatType.DND5e,
+                chatRollMode:
+                  ChatRollMode[game.settings.get("core", "rollMode")],
               },
             });
           }
@@ -224,6 +231,7 @@ export default class SetupHooksDND5e {
               actorId: actor.id,
               flavor: roll.options.flavor,
               tokenName: actor.prototypeToken.name,
+              chatRollMode: ChatRollMode[game.settings.get("core", "rollMode")],
             },
           });
         },
@@ -242,6 +250,7 @@ export default class SetupHooksDND5e {
               actorId: actor.id,
               flavor: roll.options.flavor,
               tokenName: actor.prototypeToken.name,
+              chatRollMode: ChatRollMode[game.settings.get("core", "rollMode")],
             },
           });
         },
@@ -260,6 +269,7 @@ export default class SetupHooksDND5e {
               actorId: actor.id,
               flavor: roll.options.flavor,
               tokenName: actor.prototypeToken.name,
+              chatRollMode: ChatRollMode[game.settings.get("core", "rollMode")],
             },
           });
         },
@@ -302,6 +312,7 @@ export default class SetupHooksDND5e {
               payload.data.workflow.diceTotal,
               payload.data.rollCheck.tokenName ?? payload.data.rollCheck.name,
               payload.data.workflow.actor.id,
+              payload.data.chatRollMode,
             );
             break;
           case "dnd5e.rollAttack":
@@ -310,6 +321,7 @@ export default class SetupHooksDND5e {
               encounterData.diceTotal,
               encounterData.tokenName ?? encounterData.actor.actorName,
               encounterData.actor.id,
+              payload.data.chatRollMode,
             );
             break;
           case "dnd5e.useItem":
@@ -328,6 +340,7 @@ export default class SetupHooksDND5e {
               payload.data.result,
               payload.data.tokenName ?? payload.data.alias,
               payload.data.actorId,
+              payload.data.chatRollMode,
             );
             break;
         }

--- a/scripts/SetupHooksPF2e.ts
+++ b/scripts/SetupHooksPF2e.ts
@@ -10,7 +10,7 @@ import {
   OnTrackRollStreak,
 } from "./Handlers";
 import StatManager from "./StatManager";
-import { CombatDetailType, ChatType } from "./enums";
+import { CombatDetailType, ChatType, ChatRollMode } from "./enums";
 import Stat from "./stats/Stat";
 import PF2e from "./parsers/PF2e";
 
@@ -23,6 +23,9 @@ export default class SetupHooksPF2e {
       window.Hooks.on(
         "createChatMessage",
         async function (chatMessagePF2e: ChatMessage) {
+          const chatRollMode = chatMessagePF2e.isContentVisible
+            ? ChatRollMode.publicroll
+            : ChatRollMode.selfroll;
           let chatType = chatMessagePF2e?.flags?.pf2e?.context?.type;
           if (!chatType) {
             if (chatMessagePF2e.isDamageRoll) {
@@ -46,6 +49,7 @@ export default class SetupHooksPF2e {
               ).result ?? 0,
               chatMessagePF2e.token.name,
               chatMessagePF2e.actor.id,
+              chatRollMode,
             );
           }
           if (chatType === "damage-roll") {
@@ -71,6 +75,7 @@ export default class SetupHooksPF2e {
               ).result ?? 0,
               chatMessagePF2e.token.name,
               chatMessagePF2e.actor.id,
+              chatRollMode,
             );
           }
         },

--- a/scripts/enums.ts
+++ b/scripts/enums.ts
@@ -7,6 +7,13 @@ export enum CombatDetailType {
   None = "none",
 }
 
+export enum ChatRollMode {
+  selfroll = "selfroll",
+  publicroll = "publicroll",
+  gmroll = "gmroll",
+  blindroll = "blindroll",
+}
+
 export enum RoleType {
   Fumble = "fumble",
   Critial = "critical",

--- a/scripts/mockdata/campaignStats1.ts
+++ b/scripts/mockdata/campaignStats1.ts
@@ -137,7 +137,14 @@ export const campaignStats1: CampaignStat = {
                   "spellName": "Potion of Healing (Greater)",
                   "total": 15,
                   "date": "30 September 2022 20:03"
-              }
+              },
+              {
+                "actorName": "Graa",
+                "itemLink": "@UUID[Actor.2ybHnw0DeYqwDPyV.Item.yAmmCAv5PSEM8X5f]{Potion of Healing (Greater)}",
+                "spellName": "Potion of Healing (Greater)",
+                "total": 15,
+                "date": "30 September 2022 20:03"
+            }
           ]
       }
   ],

--- a/scripts/panels/CampaignStatsPanel.ts
+++ b/scripts/panels/CampaignStatsPanel.ts
@@ -31,6 +31,13 @@ export default class CampaignStatsPanel extends FormApplication {
   }
 
   deleteStatistics() {
+    const filename = `encounter-stats-export.json`;
+    saveDataToFile(
+      JSON.stringify(Gamemaster.GetStats, null, 2),
+      "text/json",
+      filename
+    );
+
     Gamemaster.DeleteStats();
     return ui.notifications?.info(
       Trans.Get("Settings.CampaignStatsDeleted")

--- a/scripts/panels/CampaignTrackingPanel.ts
+++ b/scripts/panels/CampaignTrackingPanel.ts
@@ -1,5 +1,10 @@
 import Trans from "../Helpers/Trans";
-import { MODULE_NAME, OPT_SETTINGS_DICE_STREAK_ENABLE, OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE } from "../Settings";
+import {
+  MODULE_NAME,
+  OPT_SETTINGS_DICE_STREAK_ENABLE,
+  OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE,
+  OPT_SETTINGS_DICE_STREAK_THRESHOLD,
+} from "../Settings";
 import { SettingsList, UpdateObject } from "./Helpers";
 
 export default class CampaignTrackingPanel extends FormApplication {
@@ -23,6 +28,7 @@ export default class CampaignTrackingPanel extends FormApplication {
     const settings = [
       OPT_SETTINGS_DICE_STREAK_ENABLE,
       OPT_SETTINGS_DICE_STREAK_TO_CHAT_ENABLE,
+      OPT_SETTINGS_DICE_STREAK_THRESHOLD,
     ];
 
     return {

--- a/scripts/stats/Stat.test.ts
+++ b/scripts/stats/Stat.test.ts
@@ -262,6 +262,24 @@ describe("Stat", () => {
     });
 
     describe("If you add a new Kill", () => {
+      test("you can see None as the most kills with no kills", async () => {
+        await stat.AddCombatant(actor, "tokenId", null);
+        await stat.AddCombatant(actorTwo, "tokenId2", null);
+        stat.Save();
+        expect(stat.encounter.top.mostKills).toBe("None<br />0");
+      });
+
+      test("you can see the kill added with 2 sharing the same value", async () => {
+        await stat.AddCombatant(actor, "tokenId", null);
+        await stat.AddCombatant(actorTwo, "tokenId2", null);
+        stat.AddKill("Acolyte", "tokenId");
+        stat.AddKill("Acolyte2", "tokenId2");
+        stat.Save();
+        expect(stat.encounter.combatants.length).toBe(2);
+        expect(stat.encounter.top.mostKills).toBe("Graa S'oua & Actor 2<br />1");
+      });
+
+
       test("you can see the kill added", async () => {
         await stat.AddCombatant(actor, "tokenId", null);
         stat.AddKill("Acolyte", "tokenId");

--- a/scripts/stats/Stat.ts
+++ b/scripts/stats/Stat.ts
@@ -354,6 +354,17 @@ export default class Stat {
           total: m.kills.length,
         };
       })
+      .reduce((a, b) => {
+        const found = a.find((e) => e.total == b.total);
+        return (
+          found
+            ? found.name !== b.name
+              ? (found.name = found.name + " & " + b.name)
+              : (found.name = found.name)
+            : a.push({ ...b }),
+          a
+        );
+      }, [])
       .reduce(function (max, obj) {
         return obj.total > max.total ? obj : max;
       });
@@ -373,6 +384,17 @@ export default class Stat {
           }).length,
         };
       })
+      .reduce((a, b) => {
+        const found = a.find((e) => e.total == b.total);
+        return (
+          found
+            ? found.name !== b.name
+              ? (found.name = found.name + " & " + b.name)
+              : (found.name = found.name)
+            : a.push({ ...b }),
+          a
+        );
+      }, [])
       .reduce(function (max, obj) {
         return obj.total > max.total ? obj : max;
       });
@@ -392,6 +414,17 @@ export default class Stat {
           }).length,
         };
       })
+      .reduce((a, b) => {
+        const found = a.find((e) => e.total == b.total);
+        return (
+          found
+            ? found.name !== b.name
+              ? (found.name = found.name + " & " + b.name)
+              : (found.name = found.name)
+            : a.push({ ...b }),
+          a
+        );
+      }, [])
       .reduce(function (max, obj) {
         return obj.total > max.total ? obj : max;
       });
@@ -411,6 +444,17 @@ export default class Stat {
           }).length,
         };
       })
+      .reduce((a, b) => {
+        const found = a.find((e) => e.total == b.total);
+        return (
+          found
+            ? found.name !== b.name
+              ? (found.name = found.name + " & " + b.name)
+              : (found.name = found.name)
+            : a.push({ ...b }),
+          a
+        );
+      }, [])
       .reduce(function (max, obj) {
         return obj.total > max.total ? obj : max;
       });

--- a/scripts/stats/Stat.ts
+++ b/scripts/stats/Stat.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-self-assign */
 import StatManager from "../StatManager";
 import {
   CombatantType,


### PR DESCRIPTION
# Description

* When a player rolls doesn't roll in public, streaks are hidden from the chat #612
* Add your own threshold for dice streaks. Default is still 2 or more. #612
* When you delete the campaign data from the setting menu you will get a forced download of your data to prevent accidental deletion
* If more than one player is tieing for a top stat position their names are all displayed instead of alphabetical first #546

Fixes #546
Fixes #612
